### PR TITLE
Add CMake project LANGUAGES CXX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(autotidy)
+project(autotidy LANGUAGES CXX)
 
 # Global project settings
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Declare C++ language to avoid C language checks, a micro-optimisation but also allows to specify CXX without CC in command line.

-----

Before

```
$ CXX=/usr/bin/clang++-7 cmake -S . -B _build
-- The C compiler identification is GNU 5.5.0
-- The CXX compiler identification is Clang 7.0.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
```

After

```
$ CXX=/usr/bin/clang++-7 cmake -S . -B _build
-- The CXX compiler identification is Clang 7.0.1
-- Check for working CXX compiler: /usr/bin/clang++-7
-- Check for working CXX compiler: /usr/bin/clang++-7 -- works
```